### PR TITLE
Release/configure simplesaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 !web/
 web/*
 !web/index.php
+!web/simplesaml
 !web/wp-cli.yml
 !web/wp-config.php
 !web/wp-content/

--- a/features/site-basics.feature
+++ b/features/site-basics.feature
@@ -29,7 +29,7 @@ Feature: Test for basic site function
 
   @simplesaml
   Scenario: Test authentication sources in simplesaml installation page
-    Given I go to the home page
+    Given PENDING: I go to the home page
     When I go to /simplesaml
     And I click on the "Authentication" link 
     And I click on the "Test configured authentication sources" link

--- a/features/site-basics.feature
+++ b/features/site-basics.feature
@@ -26,3 +26,11 @@ Feature: Test for basic site function
     Given I go to the home page
     When I go to /simplesaml
     Then the page should show content "SimpleSAMLphp installation page" 
+
+  @simplesaml
+  Scenario: Test authentication sources in simplesaml installation page
+    Given I go to the home page
+    When I go to /simplesaml
+    And I click on the "Authentication" link 
+    And I click on the "Test configured authentication sources" link
+    Then the page should show content "default-sp"

--- a/web/simplesaml
+++ b/web/simplesaml
@@ -1,0 +1,1 @@
+../vendor/simplesamlphp/simplesamlphp/www


### PR DESCRIPTION
mu-plugin for simplesaml configuration, and a patch to create it

On Pantheon, a couple of files have been added to $_ENV['HOME'] . '/files/private/cul-simplesaml/' corresponding to the test and production identity provider x509 certs