### PR TITLE
Release/v1.2.18 wp-ultimate-csv-importer-pro Upper Case Uninstall.php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -73,7 +73,7 @@
     "cul-it/facetwp": "3.4.0.1",
     "cul-it/wp-libcal-hours": "1.0.6",
     "cul-it/wp-rss-aggregator": "4.15.0.2",
-    "cul-it/wp-ultimate-csv-importer-pro": "6.0.1.5",
+    "cul-it/wp-ultimate-csv-importer-pro": "6.0.1.6",
     "cweagans/composer-patches": "~1.0",
     "guzzlehttp/guzzle": "6.3.3",
     "pantheon-systems/quicksilver-pushback": "1.0.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7a22d42a218d87ba7534973e6875bb04",
+    "content-hash": "9c658f1ee200cfc0d3ec313174343130",
     "packages": [
         {
             "name": "a5hleyrich/wp-background-processing",
@@ -417,16 +417,16 @@
         },
         {
             "name": "cul-it/wp-ultimate-csv-importer-pro",
-            "version": "v6.0.1.5",
+            "version": "v6.0.1.6",
             "source": {
                 "type": "git",
                 "url": "git@github.com:cul-it/wp-ultimate-csv-importer-pro.git",
-                "reference": "b4ba287015a3b8096f9c606609a9c16d0b377bc4"
+                "reference": "949ececebb7565e859ce4b96c4fedaaaff6e70b5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cul-it/wp-ultimate-csv-importer-pro/zipball/b4ba287015a3b8096f9c606609a9c16d0b377bc4",
-                "reference": "b4ba287015a3b8096f9c606609a9c16d0b377bc4",
+                "url": "https://api.github.com/repos/cul-it/wp-ultimate-csv-importer-pro/zipball/949ececebb7565e859ce4b96c4fedaaaff6e70b5",
+                "reference": "949ececebb7565e859ce4b96c4fedaaaff6e70b5",
                 "shasum": ""
             },
             "require": {
@@ -436,10 +436,10 @@
             "type": "wordpress-plugin",
             "description": "WordPress plugin for Unified Library Website",
             "support": {
-                "source": "https://github.com/cul-it/wp-ultimate-csv-importer-pro/tree/v6.0.1.5",
+                "source": "https://github.com/cul-it/wp-ultimate-csv-importer-pro/tree/v6.0.1.6",
                 "issues": "https://github.com/cul-it/wp-ultimate-csv-importer-pro/issues"
             },
-            "time": "2019-09-11T19:37:09+00:00"
+            "time": "2019-09-26T20:30:16+00:00"
         },
         {
             "name": "cweagans/composer-patches",


### PR DESCRIPTION
    "cul-it/wp-ultimate-csv-importer-pro": "6.0.1.6",
