### PR TITLE
bump version number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - wp-rss-aggregator plugin - 4.17.7 - licence expired - [Issue](https://github.com/cul-it/uls/issues/865)
 - Siteimprove plugin - 1.2.0 - plugin unknown Compatibility with WordPress 5.5
 
+## [v1.4.4] - 2020-08-03
+### Changed
+- created this version since the v1.4.3 tag is already used
+
 ## [v1.4.3] - 2020-08-03
 ### Added
 - Add symfony/yaml dependency - Used downstream by CULU theme to support central config.
@@ -366,6 +370,7 @@ Relevanssi - 4.6.0 - see [Changelog](https://wordpress.org/plugins/relevanssi/#d
 - all-in-one-wp-migration v7.8 update
 
 [Unreleased]: https://github.com/cul-it/ci-jenkins-pantheon-wordpress/releases/latest...HEAD
+[v1.4.4]: https://github.com/cul-it/ci-jenkins-pantheon-wordpress/releases/tag/v1.4.4
 [v1.4.3]: https://github.com/cul-it/ci-jenkins-pantheon-wordpress/releases/tag/v1.4.3
 [v1.4.2]: https://github.com/cul-it/ci-jenkins-pantheon-wordpress/releases/tag/v1.4.2
 [v1.4.1]: https://github.com/cul-it/ci-jenkins-pantheon-wordpress/releases/tag/v1.4.1


### PR DESCRIPTION
Tag already exists for v1.4.3 due to interaction with SourceTree.