### PR TITLE
Bump CULU theme to v1.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - wp-rss-keyword-filtering plugin - 1.7 - can not download - licence expired
 - wp-rss-aggregator plugin - 4.17.7 - licence expired - [Issue](https://github.com/cul-it/uls/issues/865)
 - Siteimprove plugin - 1.2.0 - plugin unknown Compatibility with WordPress 5.5
+- [CULU theme v1.4.2](https://github.com/cul-it/wp-cul-theme-culu/releases/tag/v1.4.2)
 
 ## [v1.4.5] - 2020-08-14
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -82,7 +82,7 @@
     "composer/installers": "^1.3.0",
     "cul-it/advanced-custom-fields-pro": "5.8.14",
     "cul-it/ares_wordpress": "1.0.7",
-    "cul-it/culu": "1.4.1",
+    "cul-it/culu": "1.4.2",
     "cul-it/draw-attention-pro": "1.9.12.1",
     "cul-it/elementor-pro": "2.10.3",
     "cul-it/facetwp-conditional-logic": "1.3.0.1",


### PR DESCRIPTION
Hi @jgreidy This is a hotfix for the CULU theme to be included in next upstream release.

Two notes:
- I added an entry under the **Unreleased** section of the CHANGELOG for no, since we don't have our workflow sorted
- this does not include **composer.lock** because when I ran `composer update` locally I was seeing discrepancies beyond just the funding info that we've discussed in the past (attributed to using different versions of composer)